### PR TITLE
Check for unit.id_ == 1 which has no Coalition or Category

### DIFF
--- a/zoneCommander.lua
+++ b/zoneCommander.lua
@@ -1719,7 +1719,7 @@ do
 		ev.default = defaultReward
 		function ev:onEvent(event)
 			local unit = event.initiator
-			if unit and Object.getCategory(unit) == Object.Category.UNIT and (Unit.getCategoryEx(unit) == Unit.Category.AIRPLANE or Unit.getCategoryEx(unit) == Unit.Category.HELICOPTER)then
+			if unit and unit.id_ ~= 1 and Object.getCategory(unit) == Object.Category.UNIT and (Unit.getCategoryEx(unit) == Unit.Category.AIRPLANE or Unit.getCategoryEx(unit) == Unit.Category.HELICOPTER)then
 				local side = unit:getCoalition()
 				local groupid = unit:getGroup():getID()
 				local pname = unit:getPlayerName()


### PR DESCRIPTION
Mission crashes in new DCS version. For some reason there is a object with id_ 1 which has no getCoalition() or getCategory() function available, even though it is an object. It has a coalition of -1. This causes it to crash on the onEvent(event). 